### PR TITLE
Port to Python3

### DIFF
--- a/example.py
+++ b/example.py
@@ -48,7 +48,7 @@ if __name__ == '__main__':
     MIFS.fit(X,y)
     # calculate precision and sensitivity
     sens, prec = check_selection(np.where(MIFS.support_)[0], i, r)
-    print 'Sensitivity: ' + str(sens) + '    Precision: ' + str(prec)
+    print('Sensitivity: ' + str(sens) + '    Precision: ' + str(prec))
     
     
     # simulate dataset with continuous y 
@@ -60,4 +60,4 @@ if __name__ == '__main__':
     MIFS.fit(X,y)
     # calculate precision and sensitivity
     sens, prec = check_selection(np.where(MIFS.support_)[0], i, r)
-    print 'Sensitivity: ' + str(sens) + '    Precision: ' + str(prec)
+    print('Sensitivity: ' + str(sens) + '    Precision: ' + str(prec))

--- a/mi.py
+++ b/mi.py
@@ -54,7 +54,7 @@ def get_first_mi_vector(MI_FS, k):
     This function is for when |S| = 0. We select the first feautre in S.
     """
     n, p = MI_FS.X.shape
-    MIs = Parallel(n_jobs=num_cores)(delayed(_get_first_mi)(i, k, MI_FS) for i in xrange(p))
+    MIs = Parallel(n_jobs=num_cores)(delayed(_get_first_mi)(i, k, MI_FS) for i in range(p))
     return MIs
 
 

--- a/mifs.py
+++ b/mifs.py
@@ -203,7 +203,7 @@ class MutualInformationFeatureSelector(object):
         k_max = 11
         xy_MI = np.zeros((k_max-k_min, p))
         xy_MI[:] = np.nan
-        for i, k in enumerate(list(range(k_min, k_max))):
+        for i, k in enumerate(range(k_min, k_max)):
             xy_MI [i, :] = mi.get_first_mi_vector(self, k)
         xy_MI = bn.nanmedian(xy_MI, axis=0)
 

--- a/mifs.py
+++ b/mifs.py
@@ -185,7 +185,7 @@ class MutualInformationFeatureSelector(object):
         # list of selected features
         S = []
         # list of all features
-        F = range(p)
+        F = list(range(p))
 
         if self.n_features != 'auto':
             feature_mi_matrix = np.zeros((self.n_features, p))
@@ -203,7 +203,7 @@ class MutualInformationFeatureSelector(object):
         k_max = 11
         xy_MI = np.zeros((k_max-k_min, p))
         xy_MI[:] = np.nan
-        for i, k in enumerate(range(k_min, k_max)):
+        for i, k in enumerate(list(range(k_min, k_max))):
             xy_MI [i, :] = mi.get_first_mi_vector(self, k)
         xy_MI = bn.nanmedian(xy_MI, axis=0)
 
@@ -218,8 +218,10 @@ class MutualInformationFeatureSelector(object):
         # ----------------------------------------------------------------------
         # FIND SUBSEQUENT FEATURES
         # ----------------------------------------------------------------------
+        if self.n_features == 'auto': n_features = np.inf
+        else: n_features = self.n_features
 
-        while len(S) < self.n_features:
+        while len(S) < n_features:
             # loop through the remaining unselected features and calculate MI
             s = len(S) - 1
             feature_mi_matrix[s, F] = mi.get_mi_vector(self, F, s)
@@ -281,7 +283,7 @@ class MutualInformationFeatureSelector(object):
         if not self.categorical:
             ss = StandardScaler()
             X = ss.fit_transform(X)
-            y = ss.fit_transform(y)
+            y = ss.fit_transform(y.reshape(-1, 1))
 
         # sanity checks
         methods = ['JMI', 'JMIM', 'MRMR']
@@ -299,12 +301,11 @@ class MutualInformationFeatureSelector(object):
         if not isinstance(self.categorical, bool):
             raise ValueError('Categorical must be Boolean.')
         if self.categorical and np.unique(y).shape[0] > 5:
-            print 'Are you sure y is categorical? It has more than 5 levels.'
+            print('Are you sure y is categorical? It has more than 5 levels.')
         if not self.categorical and self._isinteger(y):
-            print 'Are you sure y is continuous? It seems to be discrete.'
+            print('Are you sure y is continuous? It seems to be discrete.')
         if self._isinteger(X):
-            print ('The values of X seem to be discrete. MI_FS will treat them'
-                   'as continuous.')
+            print('The values of X seem to be discrete. MI_FS will treat them as continuous.')
         return X, y
 
     def _add_remove(self, S, F, i):
@@ -326,4 +327,4 @@ class MutualInformationFeatureSelector(object):
 
         if self.verbose > 1:
             out += ', JMIM: ' + str(MIs[-1])
-        print out
+        print(out)


### PR DESCRIPTION
I've done the following changes:
- Changed `xrange` and `print` to the more general and backward compatible versions of python3.
- Some explicit list conversions were added when neccessary.
- Reshape of input to scikit `StandarScaler` to avoid deprecation warning.
- As string comparison trick doesn't work correctly with python3 (on `self.n_features`),  a cleaner way was introduced.

`example.py` works great on both python2 and python3, on anaconda platform.  
