### PR TITLE
slight improvement of _print_results() method

### DIFF
--- a/mifs/mifs.py
+++ b/mifs/mifs.py
@@ -343,5 +343,5 @@ class MutualInformationFeatureSelector(object):
                     str(self.n_features) + ' : ' + str(S[-1]))
 
         if self.verbose > 1:
-            out += ', JMIM: ' + str(MIs[-1])
+            out += ', ' + self.method + ' : ' + str(MIs[-1])
         print (out)


### PR DESCRIPTION
Now _print_results() returns the mutual information method selected by the user and (then) actually used for the calculation (JMI, JMIM or MRMR) instead of a fixed string 'MI'