### PR TITLE
Update mifs.py

### DIFF
--- a/mifs/mifs.py
+++ b/mifs/mifs.py
@@ -9,7 +9,7 @@ import numpy as np
 from scipy import signal
 from sklearn.utils import check_X_y
 from sklearn.preprocessing import StandardScaler
-from sklearn.externals.joblib.parallel import cpu_count
+from multiprocessing import cpu_count
 import bottleneck as bn
 from . import mi
 


### PR DESCRIPTION
sklearn.externals.joblib.parallel throws error. To get the cpu count we can use the following.
from multiprocessing import cpu_count